### PR TITLE
Clarify event schedule, improve mobile layout, and harden wishlist security

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,14 @@
     section { padding: 48px 0; }
     .section-title { font-size: clamp(26px, 3.4vw, 36px); margin: 0 0 16px; }
     .section-note { color: var(--muted); margin: 0 0 24px; }
+    .pass-warning {
+      display: inline-block;
+      padding: 2px 8px;
+      background: var(--danger);
+      color: #fff;
+      border-radius: var(--r-sm);
+      font-weight: 700;
+    }
 
     /* Инфо‑карточки */
     .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 16px; }
@@ -101,6 +109,15 @@
     .pill { padding:6px 10px; border-radius:999px; background:#f1f5f9; color:#334155; font-size:12px; font-weight:700; }
     .badge.reserved { background: #fef2f2; color: #991b1b; border: 1px dashed #fecaca; }
     .badge.free { background:#edfdf7; color:#065f46; border: 1px dashed #a7f3d0; }
+
+    /* Mobile tweaks */
+    @media (max-width: 480px) {
+      .container { padding: 16px; }
+      .nav { flex-wrap: wrap; justify-content: center; }
+      .cta { flex-direction: column; }
+      .cta .btn { width: 100%; }
+      .pass-warning { display: block; margin-top: 6px; }
+    }
 
     .filters { display:flex; gap:10px; align-items:center; margin-bottom: 12px; }
 
@@ -145,13 +162,13 @@
     <section id="details">
       <div class="container">
         <h2 class="section-title">Детали события</h2>
-        <p class="section-note">Приходите чуть заранее. <strong>⚠️ Вход строго по пропускам — пожалуйста, не опаздывайте!</strong></p>
+        <p class="section-note">Приходите чуть заранее. <span class="pass-warning">⚠️ Вход строго по пропускам, поэтому не опаздывать!!!</span></p>
 
         <div class="grid">
           <article class="card sm-4" aria-labelledby="whenTitle">
             <h3 id="whenTitle">Когда</h3>
-            <p><strong id="dateText">30 августа 2025</strong></p>
-            <p>Сбор гостей — <strong id="startTime">16:00</strong>, торжественная часть — <strong id="ceremonyTime">17:00</strong></p>
+            <p><strong id="dateText">30 августа 2025</strong> в <strong id="mainTime">15:00</strong></p>
+            <p>Сбор гостей — <strong id="startTime">13:50</strong>, торжественная часть — <strong id="ceremonyTime">14:30</strong></p>
           </article>
 
           <article class="card sm-4" aria-labelledby="whereTitle">
@@ -215,8 +232,9 @@
     const WEDDING = {
       couple: 'Руслан & Елизавета',         // Имена
       dateISO: '2025-08-30',       // Дата в формате YYYY-MM-DD
+      timeMain: '15:00',           // Основное время события
       timeStart: '13:50',          // Время сбора гостей (локальное)
-      timeCeremony: '15:00',
+      timeCeremony: '14:30',       // Торжественная часть
       timeEnd: '23:00',
       timezone: 'Europe/Moscow',   // TZID для .ics (замените при необходимости)
       venueName: 'Москоу‑Сити, башня ОКО — ресторан «Birds»',
@@ -247,6 +265,7 @@
       document.getElementById('footerNames').textContent = WEDDING.couple;
       document.getElementById('dateChip').textContent = prettyDate(dt);
       document.getElementById('dateText').textContent = dt.toLocaleDateString('ru-RU');
+      document.getElementById('mainTime').textContent = WEDDING.timeMain;
       document.getElementById('startTime').textContent = WEDDING.timeStart;
       document.getElementById('ceremonyTime').textContent = WEDDING.timeCeremony;
       document.getElementById('venueName').textContent = WEDDING.venueName;
@@ -318,16 +337,20 @@
         const reserved = isReserved(item.id);
         const owner = reservedName(item.id);
         const nameLabel = reserved ? `Забронировано — ${escapeHtml(owner)}` : 'Свободно';
+        const title = escapeHtml(item.title);
+        const note = escapeHtml(item.note || '');
+        const price = escapeHtml(item.price || '');
+        const safeLink = /^https?:\/\//i.test(item.link || '') ? item.link : '#';
         const card = document.createElement('div');
         card.className = 'wish-card';
         card.innerHTML = `
           <div class="wish-thumb" aria-hidden="true">🎁</div>
           <div class="wish-meta">
-            <h4 class="wish-title" title="${item.title}">${item.title}</h4>
-            <p class="wish-note">${item.note || ''} ${item.price ? '• '+item.price : ''}</p>
+            <h4 class="wish-title" title="${title}">${title}</h4>
+            <p class="wish-note">${note}${price ? ' • ' + price : ''}</p>
           </div>
           <div class="wish-actions">
-            <a class="btn ghost" href="${item.link || '#'}" target="_blank" rel="noopener">Смотреть</a>
+            <a class="btn ghost" href="${safeLink}" target="_blank" rel="noopener noreferrer">Смотреть</a>
             <span class="pill badge ${reserved ? 'reserved' : 'free'}">${nameLabel}</span>
             <button class="btn primary" aria-pressed="${reserved}" data-id="${item.id}">${reserved ? 'Снять бронь' : 'Забронировать'}</button>
           </div>`;


### PR DESCRIPTION
## Summary
- Add responsive layout tweaks for small screens and make pass warning flow to new line on mobiles
- Escape wishlist data and validate external links to mitigate XSS and unsafe URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f4ec0348832aac4d7969b6b83439