### PR TITLE
feat: integrate wishlist with server reservations

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,10 @@
       <div class="container">
         <h2 class="section-title">Виш‑лист</h2>
         <p class="section-note">Если вы собираетесь сделать подарок, но не знаете что и как, то мы подобрали список возможных подарков, чтобы облегчить вам жизнь. Подарок можно забронировать, чтобы не было проблемы с тем, что кто-то решит подарить тоже самое.</p>
+        <p class="section-note">
+          Бронь сохраняется в общей таблице (Google Sheets) — список видят все гости.
+          Для брони укажите имя; снять бронь можно с того же устройства (по токену) или по запросу организаторам.
+        </p>
         <div class="filters">
           <label><input type="checkbox" id="onlyFree" /> Только свободные</label>
         </div>
@@ -225,7 +229,7 @@
       mapsUrl: 'https://yandex.ru/maps/?text=Москоу-сити%20башня%20ОКО%20Birds%2084%20этаж'
     };
 
-    const WISHLIST = [
+      const WISHLIST = [
       {
         id: 'aerogrill',
         title: 'Аэрогриль',
@@ -250,10 +254,29 @@
         link: 'https://www.wildberries.ru/catalog/232577407/detail.aspx?size=366852213',
         image: 'image/постельное_бельё_2.png'
       }
-    ];
+      ];
+    </script>
+    <script>
+      const API_URL = 'https://script.google.com/macros/s/AKfycbzRsptiV_kMoljVjMwGehHmbJWXSq4QOF5PPJeRaBX_658NZMUMIuhwgG5SnroiFBWL4Q/exec';
 
-    // === УТИЛИТЫ ДАТ/ФОРМАТОВ ===
-    const dt = new Date(WEDDING.dateISO + 'T' + (WEDDING.timeStart || '12:00'));
+      async function apiList() {
+        const res = await fetch(`${API_URL}?action=list`, { method: 'GET' });
+        return res.json();
+      }
+      async function apiReserve(item_id, name) {
+        const body = new URLSearchParams({ action: 'reserve', item_id, name });
+        const res = await fetch(API_URL, { method: 'POST', body });
+        return res.json();
+      }
+      async function apiCancel(item_id, token) {
+        const body = new URLSearchParams({ action: 'cancel', item_id, token });
+        const res = await fetch(API_URL, { method: 'POST', body });
+        return res.json();
+      }
+    </script>
+    <script>
+      // === УТИЛИТЫ ДАТ/ФОРМАТОВ ===
+      const dt = new Date(WEDDING.dateISO + 'T' + (WEDDING.timeStart || '12:00'));
     const dateFormatter = new Intl.DateTimeFormat('ru-RU', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
     const prettyDate = (d) => dateFormatter.format(d).replace(/^./, c => c.toUpperCase());
 
@@ -304,87 +327,96 @@
       }
     }
 
-    const grid = document.getElementById('wishGrid');
-    const onlyFree = document.getElementById('onlyFree');
+      // === ВИШ-ЛИСТ ===
+      const grid = document.getElementById('wishGrid');
+      const onlyFree = document.getElementById('onlyFree');
 
-    // Работа с бронью подарков
-    const key = (id) => 'wish_' + id;
-    function getReservation(id) {
-      try { return JSON.parse(localStorage.getItem(key(id))) || null; } catch { return null; }
-    }
-    function isReserved(id) { const r = getReservation(id); return r && r.r === 1; }
-    function reservedName(id) { const r = getReservation(id); return r?.name || ''; }
-    function setReserved(id, name) { localStorage.setItem(key(id), JSON.stringify({ r: 1, name: name.trim() })); }
-    function clearReserved(id) { localStorage.removeItem(key(id)); }
-    function sameName(a, b) { return (a || '').trim().toLowerCase() === (b || '').trim().toLowerCase(); }
-    function escapeHtml(s) {
-      return (s || '').replace(/[&<>"']/g, (m) => ({
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#39;'
-      }[m]));
-    }
+      // Локально храним только токен отмены; активные брони берём с сервера
+      function getToken(id){ return localStorage.getItem('wish_token_'+id) || ''; }
+      function setToken(id,t){ localStorage.setItem('wish_token_'+id, t); }
+      function clearToken(id){ localStorage.removeItem('wish_token_'+id); }
 
-    function renderWishlist() {
-      grid.innerHTML = '';
-      const filtered = WISHLIST.filter(item => !(onlyFree.checked && isReserved(item.id)));
-      for (const item of filtered) {
-        const reserved = isReserved(item.id);
-        const owner = reservedName(item.id);
-        const nameLabel = reserved ? `Забронировано — ${escapeHtml(owner)}` : 'Свободно';
-        const title = escapeHtml(item.title);
-        const note = escapeHtml(item.note || '');
-        const price = escapeHtml(item.price || '');
-        const safeLink = /^https?:\/\//i.test(item.link || '') ? item.link : '#';
-        const thumb = item.image ? `<img src="${item.image}" alt="">` : (item.icon || '🎁');
-        const card = document.createElement('div');
-        card.className = 'wish-card';
-        card.innerHTML = `
-          <div class="wish-thumb" aria-hidden="true">${thumb}</div>
-          <div class="wish-meta">
-            <h4 class="wish-title" title="${title}">${title}</h4>
-            <p class="wish-note">${note}${price ? ' • ' + price : ''}</p>
-          </div>
-          <div class="wish-actions">
-            <a class="btn ghost" href="${safeLink}" target="_blank" rel="noopener noreferrer">Смотреть</a>
-            <span class="pill badge ${reserved ? 'reserved' : 'free'}">${nameLabel}</span>
-            <button class="btn primary" aria-pressed="${reserved}" data-id="${item.id}">${reserved ? 'Снять бронь' : 'Забронировать'}</button>
-          </div>`;
+      let SERVER_MAP = {}; // item_id -> name (активные брони)
 
-        card.querySelector('button').addEventListener('click', (e) => {
-          const id = e.currentTarget.getAttribute('data-id');
-          if (!isReserved(id)) {
-            let name = prompt('Введите ваше имя, чтобы забронировать подарок:');
-            if (!name) return;
-            name = name.trim();
-            if (name.length < 2) { alert('Пожалуйста, укажите имя (не короче 2 символов).'); return; }
-            setReserved(id, name);
-            renderWishlist();
-          } else {
-            const current = reservedName(id);
-            const tryName = prompt('Чтобы снять бронь, введите имя, указанное при бронировании:');
-            if (tryName === null) return;
-            if (!sameName(current, tryName)) { alert('Имя не совпадает с тем, что было указано при брони.'); return; }
-            clearReserved(id);
-            renderWishlist();
-          }
-        });
-        grid.appendChild(card);
+      async function refreshFromServer() {
+        try {
+          const { ok, reservations } = await apiList();
+          if (ok) SERVER_MAP = reservations || {};
+        } catch (e) {
+          console.error('Не удалось получить список броней', e);
+        }
       }
-      if (!filtered.length) {
-        const empty = document.createElement('div');
-        empty.className = 'card';
-        empty.textContent = 'Нет позиций по выбранному фильтру.';
-        grid.appendChild(empty);
+
+      function isReserved(id) { return Boolean(SERVER_MAP[id]); }
+      function reservedName(id) { return SERVER_MAP[id] || ''; }
+      function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m])); }
+
+      async function renderWishlist() {
+        await refreshFromServer();
+        grid.innerHTML = '';
+        const filtered = WISHLIST.filter(item => !(onlyFree.checked && isReserved(item.id)));
+        for (const item of filtered) {
+          const reserved = isReserved(item.id);
+          const owner = reservedName(item.id);
+          const nameLabel = reserved ? `Забронировано — ${escapeHtml(owner)}` : 'Свободно';
+
+          const card = document.createElement('div');
+          card.className = 'wish-card';
+          const safeLink = /^https?:\/\//i.test(item.link || '') ? item.link : '#';
+          card.innerHTML = `
+            <div class="wish-thumb" aria-hidden="true">🎁</div>
+            <div class="wish-meta">
+              <h4 class="wish-title" title="${escapeHtml(item.title)}">${escapeHtml(item.title)}</h4>
+              <p class="wish-note">${escapeHtml(item.note || '')} ${item.price ? '• '+escapeHtml(item.price) : ''}</p>
+            </div>
+            <div class="wish-actions">
+              <a class="btn ghost" href="${safeLink}" target="_blank" rel="noopener">Смотреть</a>
+              <span class="pill badge ${reserved ? 'reserved' : 'free'}">${nameLabel}</span>
+              <button class="btn primary" aria-pressed="${reserved}" data-id="${item.id}">
+                ${reserved ? 'Снять бронь' : 'Забронировать'}
+              </button>
+            </div>`;
+
+          card.querySelector('button').addEventListener('click', async (e) => {
+            const id = e.currentTarget.getAttribute('data-id');
+            if (!isReserved(id)) {
+              let name = prompt('Введите ваше имя, чтобы забронировать подарок:');
+              if (!name) return;
+              name = name.trim();
+              if (name.length < 2) { alert('Пожалуйста, укажите имя (не короче 2 символов).'); return; }
+              const r = await apiReserve(id, name);
+              if (!r || !r.ok) {
+                alert(r && r.error === 'already_reserved' ? 'Этот подарок уже успели забронировать.' : 'Ошибка бронирования. Попробуйте ещё раз.');
+                return;
+              }
+              setToken(id, r.token);
+              await renderWishlist();
+            } else {
+              const token = getToken(id);
+              if (!token) { alert('Снять бронь можно с того же устройства, где она оформлялась, либо напишите организаторам.'); return; }
+              const r = await apiCancel(id, token);
+              if (!r || !r.ok) { alert('Не удалось снять бронь.'); return; }
+              clearToken(id);
+              await renderWishlist();
+            }
+          });
+
+          grid.appendChild(card);
+        }
+        if (!filtered.length) {
+          const empty = document.createElement('div');
+          empty.className = 'card';
+          empty.textContent = 'Нет позиций по выбранному фильтру.';
+          grid.appendChild(empty);
+        }
       }
-    }
 
-    hydrateBasics();
-    renderWishlist();
+      hydrateBasics();
+      renderWishlist();
+      setInterval(renderWishlist, 30000);
+      document.addEventListener('visibilitychange', () => { if (!document.hidden) renderWishlist(); });
 
-    const timelineEl = document.getElementById('timeline');
+      const timelineEl = document.getElementById('timeline');
     if (timelineEl) {
       const observer = new IntersectionObserver((entries, obs) => {
         if (entries[0].isIntersecting) {


### PR DESCRIPTION
## Summary
- add server API calls for shared gift reservations
- sync wishlist with Google Sheets and store cancel tokens locally
- auto-refresh reservations periodically and on tab focus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899122dada8832a8fc1b29094f531fd