### PR TITLE
Enhance event detail cards layout and warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,33 +55,32 @@
  
      <section id="details">
        <div class="container">
-         <h2 class="section-title">Детали события</h2>
-         <p class="section-note">Приходите чуть заранее. <span class="pass-warning">⚠️ Вход строго по пропускам, поэтому
-             не опаздывать!!!</span></p>
- 
-         <div class="grid">
-           <article class="card sm-4" aria-labelledby="whenTitle">
-             <h3 id="whenTitle">Когда</h3>
-             <p><strong id="dateText"></strong> в <strong id="mainTime"></strong></p>
-             <p>Сбор гостей — <strong id="startTime"></strong>, торжественная часть — <strong id="ceremonyTime"></strong>
-             </p>
-           </article>
- 
-           <article class="card sm-4" aria-labelledby="whereTitle">
-             <h3 id="whereTitle">Где</h3>
-             <p id="venueName"></p>
-             <p id="venueAddr"></p>
-             <div class="address-actions">
-               <button id="mapBtn2" class="btn btn--ghost">Открыть карту</button>
-               <button id="copyAddr" class="btn btn--secondary btn--icon" aria-label="Скопировать адрес">📋</button>
-             </div>
-         </article>
- 
-           <article class="card sm-4" aria-labelledby="dressTitle">
-             <h3 id="dressTitle">Дресс‑код</h3>
-             <p>Дресс‑кода нет. Но если хотите красивые фоточки — вы знаете, что делать 😉</p>
-           </article>
-         </div>
+        <h2 class="section-title">Детали события</h2>
+        <p class="section-note section-note--warning"><strong>Приходите чуть заранее.</strong> ⚠️ Вход строго по пропускам — <strong>не опаздывайте.</strong></p>
+
+        <div class="grid">
+          <article class="card details-card" aria-labelledby="whenTitle">
+            <h3 id="whenTitle">Когда</h3>
+            <p><strong id="dateText"></strong> в <strong id="mainTime"></strong></p>
+            <p>Сбор гостей — <strong id="startTime"></strong>, торжественная часть — <strong id="ceremonyTime"></strong>
+            </p>
+          </article>
+
+          <article class="card details-card" aria-labelledby="whereTitle">
+            <h3 id="whereTitle">Где</h3>
+            <p id="venueName"></p>
+            <p id="venueAddr"></p>
+            <div class="address-actions">
+              <button id="mapBtn2" class="btn btn--ghost">Открыть карту</button>
+              <button id="copyAddr" class="btn btn--secondary btn--icon" aria-label="Скопировать адрес">📋</button>
+            </div>
+        </article>
+
+          <article class="card details-card" aria-labelledby="dressTitle">
+            <h3 id="dressTitle">Дресс‑код</h3>
+            <p>Дресс‑кода нет. Но если хотите красивые фоточки — вы знаете, что делать 😉</p>
+          </article>
+        </div>
        </div>
      </section>
  

--- a/styles.css
+++ b/styles.css
@@ -26,9 +26,10 @@ h2{font-size:clamp(28px,4vw,44px);margin-bottom:16px}
 .names,.couple-names{font-family:'Great Vibes',cursive;font-size:clamp(40px,8vw,96px);line-height:1.1;letter-spacing:.5px;color:var(--text);margin-bottom:8px}
 .container{max-width:1100px;margin:0 auto;padding:clamp(16px,4vw,32px)}
 .container p{max-width:65ch}
-.grid{display:grid;grid-template-columns:repeat(12,1fr);gap:var(--gap)}
-@media(max-width:767px){.grid{grid-template-columns:1fr}}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:var(--gap);justify-content:center}
 .card{background:#fff;border:1px solid var(--border);border-radius:var(--radius);box-shadow:0 6px 20px var(--shadow);padding:clamp(16px,4vw,32px)}
+.details-card{display:flex;flex-direction:column;gap:calc(var(--gap)/2);height:100%}
+.details-card h3{margin-bottom:8px}
 .btn{display:inline-block;border:2px solid transparent;border-radius:999px;min-height:48px;padding:.85rem 1.4rem;font-weight:600;transition:all var(--speed) ease;cursor:pointer}
 .btn--primary{background:var(--wood);color:#fff;border-color:var(--wood)}
 .btn--primary:hover,.btn--primary:focus-visible{background:var(--wood-600);border-color:var(--wood-600);transform:translateY(-1px)}
@@ -104,6 +105,7 @@ img{display:block;max-width:100%;height:auto}
 #dateChip{background:var(--wood);color:#fff;font-family:'Playfair Display',serif;font-weight:600}
 .cta{display:flex;justify-content:center;gap:var(--gap);flex-wrap:wrap;margin-top:var(--gap)}
 .section-note{margin-bottom:var(--gap);color:var(--text-2)}
+.section-note--warning{background:#fef2f2;color:#991b1b;font-weight:600;padding:calc(var(--gap)/2);border-radius:var(--radius)}
 main>section:nth-of-type(2n+1):not(.hero) .section-note{color:rgba(255,255,255,.8)}
 .banner{padding:calc(var(--gap)/2);border-radius:var(--radius);background:#fef2f2;color:#991b1b;text-align:center;margin-bottom:calc(var(--gap)/1.5)}
 dialog{border:none;border-radius:var(--radius);padding:24px;max-width:400px}
@@ -118,6 +120,6 @@ dialog menu{display:flex;gap:8px;justify-content:flex-end;margin-top:16px}
 .skeleton{position:relative;overflow:hidden;background:var(--bg-muted)}
 .skeleton::after{content:"";position:absolute;inset:0;transform:translateX(-100%);background:linear-gradient(90deg,transparent,rgba(255,255,255,.6),transparent);animation:skeleton 1.5s infinite}
 @keyframes skeleton{100%{transform:translateX(100%)}}
-.address-actions{margin-top:var(--gap);display:flex;gap:var(--gap);align-items:center}
+.address-actions{margin-top:auto;display:flex;gap:calc(var(--gap)/2);flex-wrap:wrap;align-items:center}
 .rsvp-actions{display:flex;gap:var(--gap);flex-wrap:wrap;margin-top:var(--gap)}
 .countdown{margin-top:var(--gap);font-weight:600}


### PR DESCRIPTION
## Summary
- Widen event detail cards and improve content layout
- Highlight timing notice with a warning style

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899e18b5adc832aaf77f9f84339df78