### PR TITLE
feat: apply new color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta property="og:url" content="https://crabopulus.github.io/wedding_day/" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://crabopulus.github.io/wedding_day/" />
-  <meta name="theme-color" content="#FAF4EF" />
+    <meta name="theme-color" content="#1b1a19" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@400;500;600&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
@@ -93,22 +93,22 @@
           <div class="timeline" id="timeline">
             <div class="t-item">
               <div class="t-time" id="tStart"></div>
-              <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a68a75/conference.png" alt="Сбор гостей"></div>
+                <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a8773b/conference.png" alt="Сбор гостей"></div>
               <div>Сбор гостей</div>
             </div>
             <div class="t-item">
               <div class="t-time" id="tCeremony"></div>
-              <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a68a75/tower.png" alt="Поднимаемся на башню"></div>
+                <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a8773b/tower.png" alt="Поднимаемся на башню"></div>
               <div>Поднимаемся на башню</div>
             </div>
             <div class="t-item">
               <div class="t-time" id="tMain"></div>
-              <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a68a75/wedding-rings.png" alt="Церемония"></div>
+                <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a8773b/wedding-rings.png" alt="Церемония"></div>
               <div>Церемония</div>
             </div>
             <div class="t-item">
               <div class="t-time" id="tEnd"></div>
-              <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a68a75/champagne.png" alt="Завершение"></div>
+                <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a8773b/champagne.png" alt="Завершение"></div>
               <div>Конец</div>
             </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,17 @@
 :root {
-  --bg: #FAF4EF;
-  --bg-muted: #FFF8F0;
-  --text: #8B6F5A;
-  --text-2: #A68A75;
-  --text: #A68A75;
-  --text-2: #CBB39E;
-  --wood: #D9A066;
-  --wood-600: #A68A75;
-  --sage: #E6C8A5;
-  --denim: #D9A066;
-  --border: #EBD9C3;
-  --white: #FDFDFB;
-  --shadow: rgba(139, 111, 90, 0.08);
-  --shadow: rgba(166, 138, 117, 0.08);
+  --bg: #1b1a19;
+  --bg-alt: #3e5b3a;
+  --bg-muted: #8ca3b5;
+  --text: #cbb17f;
+  --text-2: #6d7c5e;
+  --text-dark: #1b1a19;
+  --accent: #a8773b;
+  --accent-hover: #8e6a4a;
+  --secondary: #6d7c5e;
+  --secondary-hover: #3e5b3a;
+  --border: #5c4b39;
+  --surface: #e8e5e0;
+  --shadow: rgba(27, 26, 25, 0.08);
   --radius: 16px;
   --gap: 24px;
   --speed: 0.3s;
@@ -88,11 +87,12 @@ h2 {
   justify-content: center;
 }
 .card {
-  background: var(--white);
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: 0 6px 20px var(--shadow);
   padding: clamp(16px, 4vw, 32px);
+  color: var(--text-dark);
 }
 .details-card {
   display: flex;
@@ -114,14 +114,14 @@ h2 {
   cursor: pointer;
 }
 .btn--primary {
-  background: var(--wood);
-  color: var(--white);
-  border-color: var(--wood);
+  background: var(--accent);
+  color: var(--text-dark);
+  border-color: var(--accent);
 }
 .btn--primary:hover,
 .btn--primary:focus-visible {
-  background: var(--wood-600);
-  border-color: var(--wood-600);
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
   transform: translateY(-1px);
 }
 .btn--primary:disabled {
@@ -133,23 +133,23 @@ h2 {
 }
 .btn--ghost {
   background: transparent;
-  color: var(--wood-600);
-  border-color: var(--wood);
+  color: var(--accent-hover);
+  border-color: var(--accent);
 }
 .btn--ghost:hover,
 .btn--ghost:focus-visible {
-  background: var(--wood);
-  color: var(--white);
+  background: var(--accent);
+  color: var(--text-dark);
 }
 .btn--secondary {
   background: transparent;
-  color: var(--sage);
-  border-color: var(--sage);
+  color: var(--secondary);
+  border-color: var(--secondary);
 }
 .btn--secondary:hover,
 .btn--secondary:focus-visible {
-  background: var(--sage);
-  color: var(--white);
+  background: var(--secondary-hover);
+  color: var(--text);
 }
 .btn--icon {
   width: 2.5rem;
@@ -169,21 +169,21 @@ a:focus-visible {
   text-decoration: underline;
   text-underline-offset: 2px;
   text-decoration-thickness: 1px;
-  text-decoration-color: var(--denim);
+  text-decoration-color: var(--bg-muted);
 }
 .btn:focus-visible {
-  outline: 3px solid var(--denim);
+  outline: 3px solid var(--bg-muted);
   outline-offset: 2px;
 }
 a:focus-visible {
-  outline: 3px solid var(--denim);
+  outline: 3px solid var(--bg-muted);
   outline-offset: 2px;
 }
 header {
   position: sticky;
   top: 0;
   z-index: 10;
-  background: rgba(250, 244, 239, 0.8);
+  background: rgba(27, 26, 25, 0.8);
   backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--border);
 }
@@ -245,7 +245,7 @@ header.scrolled {
   display: block;
   height: 3px;
   width: 28px;
-  background: var(--wood);
+  background: var(--accent);
   transition:
     transform var(--speed) ease,
     opacity var(--speed) ease;
@@ -353,7 +353,7 @@ section {
   scroll-margin-top: 80px;
 } /* под реальную высоту header */
 main > section:nth-of-type(2n) {
-  background: var(--bg-muted);
+  background: var(--bg-alt);
 }
 main > section:nth-of-type(2n + 1):not(.hero) {
   background: var(--bg);
@@ -361,7 +361,7 @@ main > section:nth-of-type(2n + 1):not(.hero) {
 }
 main > section:nth-of-type(2n + 1):not(.hero) .card,
 main > section:nth-of-type(2n + 1):not(.hero) .wish-card {
-  color: var(--text);
+  color: var(--text-dark);
 }
 footer {
   padding: 48px 0;
@@ -378,12 +378,12 @@ textarea {
   padding: 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--white);
-  color: var(--text);
+  background: var(--surface);
+  color: var(--text-dark);
 }
 input:focus-visible,
 textarea:focus-visible {
-  outline: 2px solid var(--sage);
+  outline: 2px solid var(--secondary);
 }
 [data-reveal] {
   opacity: 0;
@@ -421,7 +421,7 @@ img {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;
-  background: var(--white);
+  background: var(--surface);
   box-shadow: 0 6px 20px var(--shadow);
   transition: transform var(--speed) ease;
 }
@@ -487,9 +487,9 @@ img {
   font-weight: 600;
 }
 .badge.reserved {
-  background: var(--sage);
-  color: var(--wood-600);
-  border: 1px dashed var(--wood-600);
+  background: var(--secondary-hover);
+  color: var(--accent-hover);
+  border: 1px dashed var(--accent-hover);
 }
 .badge.free {
   background: var(--bg-muted);
@@ -522,7 +522,7 @@ img {
   width: var(--icon-size);
   height: var(--icon-size);
   border-radius: 50%;
-  border: 2px solid var(--wood);
+  border: 2px solid var(--accent);
   background: var(--bg);
   display: flex;
   align-items: center;
@@ -535,10 +535,10 @@ img {
 .t-time {
   font-weight: 700;
   align-self: center;
-  color: var(--wood);
+  color: var(--accent);
 }
 #schedule .card {
-  background: linear-gradient(135deg, var(--white), #EBD9C3);
+  background: linear-gradient(135deg, var(--surface), var(--bg));
 }
 .nav a {
   color: var(--text-2);
@@ -569,14 +569,14 @@ img {
   gap: calc(var(--gap) / 3);
   padding: calc(var(--gap) / 3) calc(var(--gap) / 1.5);
   border-radius: 999px;
-  background: var(--white);
+  background: var(--surface);
   border: 1px solid var(--border);
   color: var(--text-2);
   box-shadow: 0 6px 20px var(--shadow);
 }
 #dateChip {
-  background: var(--wood);
-  color: var(--white);
+  background: var(--accent);
+  color: var(--text-dark);
   font-family: "Playfair Display", serif;
   font-weight: 600;
   position: absolute;
@@ -598,7 +598,7 @@ img {
 }
 .section-note--warning {
   background: var(--bg-muted);
-  color: var(--wood-600);
+  color: var(--accent-hover);
   font-weight: 600;
   padding: calc(var(--gap) / 2);
   border-radius: var(--radius);
@@ -610,7 +610,7 @@ main > section:nth-of-type(2n + 1):not(.hero) .section-note {
   padding: calc(var(--gap) / 2);
   border-radius: var(--radius);
   background: var(--bg-muted);
-  color: var(--wood-600);
+  color: var(--accent-hover);
   text-align: center;
   margin-bottom: calc(var(--gap) / 1.5);
 }
@@ -641,7 +641,7 @@ dialog menu {
   display: none;
 }
 .modal-fallback form {
-  background: var(--white);
+  background: var(--surface);
   border-radius: var(--radius);
   padding: 24px;
   max-width: 400px;
@@ -664,7 +664,7 @@ dialog menu {
   width: auto;
   height: auto;
   padding: 8px 12px;
-  background: var(--white);
+  background: var(--surface);
   border-radius: 6px;
 }
 .skeleton {


### PR DESCRIPTION
## Summary
- replace site-wide color variables with full dark palette
- apply new colors to buttons, badges, chips and schedule icons
- update browser theme color to match base background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ae08916b4832a834bc028c95d1da0