### PR TITLE
Streamline layout and hero content

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
  <body id="top">
   <header>
     <nav class="nav">
-      <div class="container nav__inner">
+      <div class="nav__inner">
         <span class="brand"><a href="#top">Приглашение</a></span>
         <button class="burger" id="burger" aria-label="Меню" aria-controls="navLinks" aria-expanded="false">
           <span></span>
@@ -50,12 +50,11 @@
     </section>
 
     <section id="details">
-      <div class="container">
         <h2 class="section-title">Детали события</h2>
         <p class="section-note section-note--warning"><strong>Приходите чуть заранее.</strong> ⚠️ Вход строго по пропускам — <strong>не опаздывайте.</strong></p>
 
         <div class="grid">
-          <article class="card details-card" aria-labelledby="whenTitle">
+          <article class="details-card" aria-labelledby="whenTitle">
             <h3 id="whenTitle">Когда</h3>
             <p><strong id="dateText"></strong> в <strong id="mainTime"></strong></p>
             <p>Сбор гостей — <strong id="startTime"></strong>, торжественная часть — <strong id="ceremonyTime"></strong>
@@ -63,7 +62,7 @@
             <div id="countdown" class="countdown"></div>
           </article>
 
-          <article class="card details-card" aria-labelledby="whereTitle">
+          <article class="details-card" aria-labelledby="whereTitle">
             <h3 id="whereTitle">Где</h3>
             <p id="venueName"></p>
             <p id="venueAddr"></p>
@@ -73,19 +72,16 @@
             </div>
         </article>
 
-          <article class="card details-card" aria-labelledby="dressTitle">
+          <article class="details-card" aria-labelledby="dressTitle">
             <h3 id="dressTitle">Дресс‑код</h3>
             <p>Дресс‑кода нет. Но если хотите красивые фоточки — вы знаете, что делать 😉</p>
           </article>
         </div>
-       </div>
      </section>
- 
+
     <section id="schedule">
-      <div class="container">
         <h2 class="section-title">Программа</h2>
-        <div class="card">
-          <div class="timeline" id="timeline">
+        <div class="timeline" id="timeline">
             <div class="t-item">
               <div class="t-time" id="tStart"></div>
                 <div class="t-icon"><img src="https://img.icons8.com/ios-filled/50/a8773b/conference.png" alt="Сбор гостей"></div>
@@ -107,19 +103,15 @@
               <div>Конец</div>
             </div>
           </div>
-        </div>
-      </div>
     </section>
 
     <section id="rsvp">
-      <div class="container">
         <h2 class="section-title">Я буду</h2>
         <p class="section-note">Пожалуйста, подтвердите своё присутствие.</p>
         <div class="rsvp-actions">
           <a class="btn btn--primary" href="https://docs.google.com/forms/d/e/1FAIpQLScud1RK1XMJ5SMcujP3-J6aizMmvnCJPqhduS6tGXu5rjCoKw/viewform?usp=pp_url&amp;entry.1234567890=Да" target="_blank" rel="noopener">Да</a>
           <a class="btn btn--ghost" href="https://docs.google.com/forms/d/e/1FAIpQLScud1RK1XMJ5SMcujP3-J6aizMmvnCJPqhduS6tGXu5rjCoKw/viewform?usp=pp_url&amp;entry.1234567890=Нет" target="_blank" rel="noopener">Нет</a>
         </div>
-      </div>
     </section>
 
     <section id="wishlist">
@@ -138,11 +130,9 @@
   </main>
 
   <footer>
-     <div class="container">
        Если возникли вопросы — напишите нам: <a href="tel:+79032274106" aria-label="Телефон"
          style="color:inherit; font-weight:700; text-decoration:none;">+7 (903) 227‑41‑06</a>
        <br />С любовью, <span id="footerNames">Имя &amp; Имя</span>
-     </div>
   </footer>
 
   <dialog id="reserveDialog">

--- a/styles.css
+++ b/styles.css
@@ -86,11 +86,11 @@ body {
   line-height: 1.5;
   background: var(--bg-primary);
   color: var(--text-primary);
-  font-size: var(--fs-16);
+  font-size: var(--fs-20);
 }
 @media (min-width: 768px) {
   body {
-    font-size: var(--fs-20);
+    font-size: var(--fs-24);
   }
 }
 h1,
@@ -106,11 +106,11 @@ h1 {
   letter-spacing: -0.02em;
 }
 h2 {
-  font-size: var(--fs-40);
+  font-size: calc(var(--fs-40) * 1.2);
   margin-bottom: 1rem;
 }
 h3 {
-  font-size: var(--fs-32);
+  font-size: calc(var(--fs-32) * 1.2);
 }
 .lead {
   font-size: var(--fs-20);
@@ -126,7 +126,7 @@ h3 {
 .names,
 .couple-names {
   font-family: var(--font-heading);
-  font-size: var(--font-display);
+  font-size: calc(var(--font-display) * 1.5);
   line-height: 1.1;
   letter-spacing: 0.5px;
   color: var(--text-primary);
@@ -375,11 +375,11 @@ header.scrolled {
     position: relative;
     overflow: hidden;
     min-height: 100vh;
-    padding: var(--gap) 0;
+    padding: calc(var(--gap) * 2) 0;
     text-align: center;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
   }
   .hero::before {
@@ -393,21 +393,18 @@ header.scrolled {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    180deg,
-    rgba(250, 244, 239, 0.6) 0%,
-    rgba(250, 244, 239, 0.4) 35%,
-    rgba(250, 244, 239, 0.8) 100%
-  );
+  background: none;
   z-index: -1;
 }
 .hero .subtitle {
-  color: var(--text-2);
-  font-size: clamp(16px, 2.6vw, 22px);
+  color: var(--text-primary);
+  font-size: clamp(24px, 3.9vw, 33px);
+  margin-bottom: calc(var(--gap) * 2);
 }
 .hero .names,
 .hero .couple-names {
   text-shadow: 0 1px 0 rgba(253, 253, 251, 0.6);
+  margin-top: calc(var(--gap) * 2);
 }
 .hero > * {
   position: relative;


### PR DESCRIPTION
## Summary
- Remove white card backdrops and container wrappers outside wish list
- Emphasize hero names/date and reposition subtitle to page bottom
- Increase base text sizes for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b25d19a10832aafa1ea22f0aa9da0