### PR TITLE
Center reserve dialog and add unreserve loading indicator

### DIFF
--- a/script.js
+++ b/script.js
@@ -245,8 +245,17 @@
               } else {
                 const token = getToken(id);
                 if (!token) { alert('Снять бронь можно с того же устройства, где она оформлялась, либо напишите организаторам.'); return; }
+                const btnEl = e.currentTarget;
+                btnEl.disabled = true;
+                const prevHtml = btnEl.innerHTML;
+                btnEl.innerHTML = '<span class="spinner" aria-hidden="true"></span>';
                 const r = await apiCancel(id, token);
-                if (!r || !r.ok) { alert('Не удалось снять бронь.'); return; }
+                if (!r || !r.ok) {
+                  alert('Не удалось снять бронь.');
+                  btnEl.disabled = false;
+                  btnEl.innerHTML = prevHtml;
+                  return;
+                }
                 clearToken(id);
                 await renderWishlist();
               }

--- a/styles.css
+++ b/styles.css
@@ -651,6 +651,13 @@ dialog {
   padding: 24px;
   max-width: 400px;
 }
+dialog[open] {
+  margin: 0;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
 dialog::backdrop {
   background: rgba(0, 0, 0, 0.4);
 }
@@ -677,6 +684,20 @@ dialog menu {
   padding: 24px;
   max-width: 400px;
   width: 90%;
+}
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 .hidden {
   display: none;


### PR DESCRIPTION
## Summary
- Ensure reserve dialog opens centered on screen
- Show spinner while removing wishlist reservations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2dcacfb4832a9e19890cc68c7bc6