### PR TITLE
feat: refresh hero layout and unify site background

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -6,13 +6,13 @@ Design tokens derived from reference “Эко”.
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `--bg-primary` | `#f7f6f2` | основной фон |
-| `--bg-secondary` | `#efede8` | вторичный фон и карточки |
+| `--bg-primary` | `#ffffff` | основной фон |
+| `--bg-secondary` | `#ffffff` | вторичный фон (совпадает с основным) |
 | `--text-primary` | `#3f3f3c` | основной текст |
 | `--text-secondary` | `#6b6b66` | второстепенный текст |
 | `--accent-1` | `#8a9d91` | зелёный акцент, основные кнопки |
 | `--accent-2` | `#d4a373` | тёплый акцент |
-| `--muted` | `#e5e2da` | приглушённые элементы |
+| `--muted` | `#ffffff` | приглушённые элементы |
 | `--border` | `#d2cec5` | границы и контуры |
 | `--surface` | `#ffffff` | поверхности |
 | `--shadow` | `0 8px 24px rgba(0,0,0,.06)` | тени |

--- a/index.html
+++ b/index.html
@@ -45,9 +45,10 @@
 
   <main>
     <section class="hero">
+      <p class="hero-date" id="dateTextHero"></p>
+      <img src="image/background.jpg" alt="Фото пары" class="hero-photo" />
       <h1 class="couple-names" id="coupleNames"></h1>
       <p class="subtitle" id="heroInvite"></p>
-      <p class="hero-date" id="dateTextHero"></p>
     </section>
 
     <section id="calendar" class="calendar-section">

--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,13 @@
 /* Design tokens inspired by "Эко" */
 :root {
   /* Цвета */
-  --bg-primary: #f7f6f2;
-  --bg-secondary: #efede8;
+  --bg-primary: #ffffff;
+  --bg-secondary: #ffffff;
   --text-primary: #3f3f3c;
   --text-secondary: #6b6b66;
   --accent-1: #8a9d91;
   --accent-2: #d4a373;
-  --muted: #e5e2da;
+  --muted: #ffffff;
   --border: #d2cec5;
   --surface: #ffffff;
   --shadow: 0 8px 24px rgba(0,0,0,.06);
@@ -377,46 +377,32 @@ header.scrolled {
     min-height: 100vh;
     padding: calc(var(--gap) * 2) var(--space-3);
     text-align: center;
+    color: var(--text-primary);
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     align-items: center;
+    gap: var(--gap);
   }
-  .hero::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: url("image/background.jpg") center/cover no-repeat;
-    z-index: -2;
-  }
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: none;
-  z-index: -1;
-}
 .hero .subtitle {
-  color: var(--white);
   font-size: clamp(24px, 3.9vw, 33px);
-  margin-bottom: calc(var(--gap) * 2);
-  text-shadow: 0 2px 4px rgba(0,0,0,.5);
+  margin-top: auto;
 }
 .hero-date {
-  color: var(--white);
   font-family: var(--font-date);
   font-size: clamp(24px, 3.9vw, 33px);
-  text-shadow: 0 2px 4px rgba(0,0,0,.5);
-  margin-bottom: calc(var(--gap) * 2);
+  margin-bottom: var(--gap);
 }
 .hero .names,
 .hero .couple-names {
-  color: var(--white);
-  text-shadow: 0 2px 4px rgba(0,0,0,.7);
-  margin-top: calc(var(--gap) * 2);
+  margin-top: 0;
 }
 .hero > * {
   position: relative;
+}
+
+.hero-photo {
+  width: clamp(200px, 60vw, 380px);
+  height: auto;
 }
 
 .calendar-table {


### PR DESCRIPTION
## Summary
- redesign hero section layout by showing date first, new hero photo, and invite text at the bottom
- set all hero text to dark color and remove background image
- standardize site background tokens to pure white and document new palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b394e8230832ab8c3af69ee215005