### PR TITLE
Единый стиль заголовков и таймер под календарём

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,24 @@
           </tr>
         </tbody>
       </table>
+      <div id="countdown" class="countdown">
+        <div class="time-part">
+          <div class="digits" id="cd-days"><span class="digit">0</span><span class="digit">0</span></div>
+          <span class="label">дней</span>
+        </div>
+        <div class="time-part">
+          <div class="digits" id="cd-hours"><span class="digit">0</span><span class="digit">0</span></div>
+          <span class="label">часов</span>
+        </div>
+        <div class="time-part">
+          <div class="digits" id="cd-minutes"><span class="digit">0</span><span class="digit">0</span></div>
+          <span class="label">минут</span>
+        </div>
+        <div class="time-part">
+          <div class="digits" id="cd-seconds"><span class="digit">0</span><span class="digit">0</span></div>
+          <span class="label">секунд</span>
+        </div>
+      </div>
     </section>
 
     <section id="details">
@@ -126,7 +144,6 @@
             <p><strong id="dateText"></strong> в <strong id="mainTime"></strong></p>
             <p>Сбор гостей — <strong id="startTime"></strong>, торжественная часть — <strong id="ceremonyTime"></strong>
             </p>
-            <div id="countdown" class="countdown"></div>
           </article>
 
           <article class="details-card" aria-labelledby="whereTitle">

--- a/script.js
+++ b/script.js
@@ -102,16 +102,24 @@
       const el = document.getElementById('countdown');
       if (!el) return;
       const target = new Date(`${WEDDING.dateISO}T${WEDDING.timeMain}:00+03:00`);
+      const dd = el.querySelectorAll('#cd-days .digit');
+      const hh = el.querySelectorAll('#cd-hours .digit');
+      const mm = el.querySelectorAll('#cd-minutes .digit');
+      const ss = el.querySelectorAll('#cd-seconds .digit');
       function update() {
         const diff = target - new Date();
-        if (diff <= 0) { el.textContent = ''; el.style.display = 'none'; clearInterval(timer); return; }
-        const d = Math.floor(diff / 86400000);
-        const h = Math.floor(diff % 86400000 / 3600000);
-        const m = Math.floor(diff % 3600000 / 60000);
-        el.textContent = `Осталось ${d}д ${h}ч ${m}м`;
+        if (diff <= 0) { el.style.display = 'none'; clearInterval(timer); return; }
+        const d = String(Math.floor(diff / 86400000)).padStart(2, '0');
+        const h = String(Math.floor(diff % 86400000 / 3600000)).padStart(2, '0');
+        const m = String(Math.floor(diff % 3600000 / 60000)).padStart(2, '0');
+        const s = String(Math.floor(diff % 60000 / 1000)).padStart(2, '0');
+        dd[0].textContent = d[0]; dd[1].textContent = d[1];
+        hh[0].textContent = h[0]; hh[1].textContent = h[1];
+        mm[0].textContent = m[0]; mm[1].textContent = m[1];
+        ss[0].textContent = s[0]; ss[1].textContent = s[1];
       }
       update();
-      const timer = setInterval(update, 60000);
+      const timer = setInterval(update, 1000);
     }
 
     // === КАЛЕНДАРЬ (.ICS) ===

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,8 @@
   --font-xxl: var(--fs-40);
   --font-display: var(--fs-56);
 
+  --heading-size: var(--fs-56);
+
   --radius: var(--radius-lg);
   --gap: var(--space-3);
   --speed: var(--dur-mid);
@@ -99,18 +101,12 @@ h3,
 h4 {
   font-family: var(--font-heading);
   color: var(--text-primary);
+  font-size: var(--heading-size);
 }
-h1 {
-  font-size: var(--fs-56);
-  line-height: 1.2;
-  letter-spacing: -0.02em;
-}
-h2 {
-  font-size: calc(var(--fs-40) * 1.2);
+h2,
+h3,
+h4 {
   margin-bottom: 1rem;
-}
-h3 {
-  font-size: calc(var(--fs-32) * 1.2);
 }
 .lead {
   font-size: var(--fs-20);
@@ -126,7 +122,7 @@ h3 {
 .names,
 .couple-names {
   font-family: var(--font-heading);
-  font-size: calc(var(--font-display) * 1.5);
+  font-size: var(--heading-size);
   line-height: 1.1;
   letter-spacing: 0.5px;
   color: var(--text-primary);
@@ -389,8 +385,8 @@ header.scrolled {
 }
 .hero-date {
   font-family: var(--font-date);
-  font-size: clamp(24px, 3.9vw, 33px);
-  margin-bottom: var(--gap);
+  font-size: var(--heading-size);
+  margin-bottom: 0;
 }
 .hero .names,
 .hero .couple-names {
@@ -407,6 +403,8 @@ header.scrolled {
 
 .calendar-table {
   width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
   border-collapse: collapse;
   font-family: var(--font-date);
 }
@@ -442,6 +440,12 @@ header.scrolled {
 section {
   padding: clamp(64px, 8vw, 96px) var(--space-3);
   scroll-margin-top: 80px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
 } /* под реальную высоту header */
 main > section:nth-of-type(2n) {
   background: var(--bg-alt);
@@ -524,7 +528,7 @@ img {
 }
 .wish-thumb {
   width: 100%;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 1;
   border-radius: calc(var(--radius) / 2);
   background: var(--bg-muted);
   display: flex;
@@ -533,9 +537,9 @@ img {
   overflow: hidden;
 }
 .wish-thumb img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 .wish-actions {
   width: 100%;
@@ -788,7 +792,34 @@ dialog menu {
 }
 .countdown {
   margin-top: var(--gap);
-  font-weight: 600;
+  display: flex;
+  gap: var(--space-4);
+}
+
+.countdown .time-part {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.countdown .digits {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.countdown .digit {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--text-primary);
+  font-size: var(--fs-32);
+}
+
+.countdown .label {
+  margin-top: 0.25rem;
+  font-size: var(--fs-14);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- Уменьшен заголовок пары и выровнены все заголовки и текст по центру
- Перенесён и переработан таймер обратного отсчёта под календарём
- Увеличены изображения подарков в разделе виш-листа

## Testing
- `npm test` *(ошибка: отсутствует package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4a589e34832aa4cb50d7386299ac