### PR TITLE
feat: add visual separators

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,8 @@
       <p class="subtitle" id="heroInvite"></p>
     </section>
 
+    <img src="image/Space_2.jpg" alt="" class="section-divider" />
+
     <section id="calendar" class="calendar-section">
       <h2 class="section-title">Календарь</h2>
       <table class="calendar-table" aria-label="Календарь Август 2025">
@@ -134,6 +136,8 @@
         </div>
       </div>
     </section>
+
+    <img src="image/Space_1.jpg" alt="" class="section-divider" />
 
     <section id="details">
         <h2 class="section-title">Детали события</h2>

--- a/styles.css
+++ b/styles.css
@@ -142,6 +142,11 @@ h4 {
   max-width: 1200px;
   margin: 0 auto;
 }
+.section-divider {
+  display: block;
+  width: 100%;
+  margin: 0;
+}
 .container p {
   max-width: 65ch;
 }


### PR DESCRIPTION
## Summary
- add full-width divider images between hero, calendar, and details sections
- style divider images to span the full width of the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba4900994832a81a4a27fd4ed32b1