### PR TITLE
Reduce spacing around calendar section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -413,6 +413,11 @@ header.scrolled {
   height: auto;
 }
 
+#calendar {
+  min-height: auto;
+  padding: clamp(32px, 4vw, 48px) var(--space-3);
+}
+
 .calendar-table {
   width: 100%;
   max-width: 400px;


### PR DESCRIPTION
## Summary
- shrink vertical spacing around calendar by removing forced viewport height and reducing padding

## Testing
- `npm test` (fails: ENOENT package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba60a8878832a84e780d14b59856b