### PR TITLE
Стилизовать кнопку фильтра в виш-листе

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,13 +209,15 @@
            возможных подарков, чтобы облегчить вам жизнь. Подарок можно забронировать, чтобы не было проблемы с тем, что
            кто-то решит подарить тоже самое.</p>
          <div id="wishError" class="banner hidden">Сервер недоступен, статусы могут быть неточны</div>
-         <div class="filters">
-           <label class="filter-option">
-             <img src="https://img.icons8.com/ios-glyphs/20/a8773b/filter.png" alt="" aria-hidden="true" />
-             <input type="checkbox" id="onlyFree" />
-             <span>Только свободные</span>
-           </label>
-         </div>
+        <div class="filters">
+          <label class="filter-option">
+            <input type="checkbox" id="onlyFree" />
+            <svg class="filter-icon" viewBox="0 0 24 24" aria-hidden="true" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none">
+              <polygon points="22 3 2 3 10 13 10 19 14 21 14 13 22 3" />
+            </svg>
+            <span>Только свободные</span>
+          </label>
+        </div>
         <div id="wishGrid" class="wish-grid" role="status" aria-live="polite"></div>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -656,17 +656,36 @@ img {
   margin-bottom: calc(var(--gap) / 1.5);
 }
 .filter-option {
-  display: flex;
+  position: relative;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px 8px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
   background: var(--surface);
+  cursor: pointer;
+  transition: background-color var(--dur-mid) var(--easing), border-color var(--dur-mid) var(--easing), color var(--dur-mid) var(--easing);
 }
-.filter-option img {
+.filter-option:hover {
+  border-color: var(--accent-1);
+}
+.filter-option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+.filter-option .filter-icon {
   width: 20px;
   height: 20px;
+}
+.filter-option:has(input:checked) {
+  background: var(--accent-1);
+  border-color: var(--accent-1);
+  color: var(--surface);
+}
+.filter-option:has(input:checked) .filter-icon {
+  stroke: currentColor;
 }
 .section-note {
   margin-bottom: var(--gap);


### PR DESCRIPTION
## Summary
- Заменена иконка фильтра в виш-листе на встроенный SVG и скрыт стандартный чекбокс
- Добавлены стили, чтобы кнопка фильтра соответствовала общей цветовой схеме

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/wedding_day/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689c22727d84832aa1c618422035d34a