### PR TITLE
Improve security and error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,7 @@
   <meta property="og:url" content="https://crabopulus.github.io/wedding_day/" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="canonical" href="https://crabopulus.github.io/wedding_day/" />
-    <meta name="theme-color" content="#1b1a19" />
-  <meta name="theme-color" content="#8ca3b5" />
+    <meta name="theme-color" content="#8ca3b5" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Great+Vibes&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
@@ -196,7 +195,7 @@
         <h2 class="section-title">Я буду</h2>
         <p class="section-note">Пожалуйста, подтвердите своё присутствие.</p>
         <div class="rsvp-actions">
-          <a class="btn btn--primary" href="https://docs.google.com/forms/d/e/1FAIpQLScud1RK1XMJ5SMcujP3-J6aizMmvnCJPqhduS6tGXu5rjCoKw/viewform?usp=pp_url" target="_blank" rel="noopener">Открыть форму подтверждения</a>
+          <a class="btn btn--primary" href="https://docs.google.com/forms/d/e/1FAIpQLScud1RK1XMJ5SMcujP3-J6aizMmvnCJPqhduS6tGXu5rjCoKw/viewform?usp=pp_url" target="_blank" rel="noopener noreferrer">Открыть форму подтверждения</a>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -44,16 +44,19 @@
 
       async function apiList() {
         const res = await fetch(`${API_URL}?action=list`, { method: 'GET' });
+        if (!res.ok) throw new Error('Network response was not ok');
         return res.json();
       }
       async function apiReserve(item_id, name) {
         const body = new URLSearchParams({ action: 'reserve', item_id, name });
         const res = await fetch(API_URL, { method: 'POST', body });
+        if (!res.ok) throw new Error('Network response was not ok');
         return res.json();
       }
       async function apiCancel(item_id, token) {
         const body = new URLSearchParams({ action: 'cancel', item_id, token });
         const res = await fetch(API_URL, { method: 'POST', body });
+        if (!res.ok) throw new Error('Network response was not ok');
         return res.json();
       }
       // === УТИЛИТЫ ДАТ/ФОРМАТОВ ===
@@ -130,7 +133,7 @@
     function downloadICS() {
       const tz = WEDDING.timezone || 'Europe/Moscow';
       const compact = (s) => s.replace(/[-:]/g, '');
-      const escape = (s) => s.replace(/,/g, '\\,').replace(/;/g, '\\;');
+      const escape = (s) => s.replace(/[\n,;]/g, (ch) => ({ '\n': '\\n', ',': '\\,', ';': '\\;' }[ch]));
       const start = `${compact(WEDDING.dateISO)}T${compact(WEDDING.timeMain)}00`;
       const end = `${compact(WEDDING.dateISO)}T${compact(WEDDING.timeEnd)}00`;
       const nowUTC = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d+Z/, 'Z');
@@ -158,19 +161,21 @@
     }
 
     function openMap() {
-      window.open(mapUrl(), '_blank', 'noopener');
+      window.open(mapUrl(), '_blank', 'noopener,noreferrer');
     }
 
-    function copyAddress() {
-      const full = `${WEDDING.venueName}, ${WEDDING.address}`;
-      navigator.clipboard.writeText(full).then(() => {
-        const msg = document.getElementById('copyMsg');
-        if (msg) {
-          msg.textContent = 'Адрес скопирован';
-          setTimeout(() => { msg.textContent = ''; }, 3000);
-        }
-      });
-    }
+      function copyAddress() {
+        const full = `${WEDDING.venueName}, ${WEDDING.address}`;
+        navigator.clipboard.writeText(full).then(() => {
+          const msg = document.getElementById('copyMsg');
+          if (msg) {
+            msg.textContent = 'Адрес скопирован';
+            setTimeout(() => { msg.textContent = ''; }, 3000);
+          }
+        }).catch(() => {
+          alert('Не удалось скопировать адрес');
+        });
+      }
 
 
       // === ВИШ-ЛИСТ ===
@@ -258,7 +263,7 @@
               <p class="wish-note">${escapeHtml(item.note || '')} ${item.price ? '• '+escapeHtml(item.price) : ''}</p>
             </div>
             <div class="wish-actions">
-              <a class="btn btn--ghost" href="${safeLink}" target="_blank" rel="noopener">Смотреть</a>
+                <a class="btn btn--ghost" href="${safeLink}" target="_blank" rel="noopener noreferrer">Смотреть</a>
               <span class="pill badge ${reserved ? 'reserved' : 'free'}">${nameLabel}</span>
               <button class="btn btn--primary" ${btnDisabled} aria-pressed="${reserved}" data-id="${item.id}">
                 ${btnLabel}


### PR DESCRIPTION
## Summary
- remove duplicate theme color meta tag
- add security attributes for external links
- harden wishlist API calls and clipboard interactions
- escape ICS content properly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c24c27448832a9deb71629a978723