### PR TITLE
feat: show spinner while reloading wishlist

### DIFF
--- a/script.js
+++ b/script.js
@@ -264,7 +264,7 @@
             if (ok) {
               SERVER_MAP = reservations || {};
               errorBanner.classList.add('hidden');
-              return;
+              return true;
             }
             throw new Error('bad response');
           } catch (e) {
@@ -276,6 +276,7 @@
             } catch (e2) {
               SERVER_MAP = {};
             }
+            return false;
           }
         }
 
@@ -292,8 +293,13 @@
       }
 
       async function renderWishlist() {
-        grid.innerHTML = WISHLIST.map(() => '<div class="wish-card skeleton" style="height:calc(128px + var(--gap))"></div>').join('');
-        await fetchWishes();
+        const overlay = document.createElement('div');
+        overlay.className = 'wish-grid__overlay';
+        overlay.innerHTML = '<span class="spinner" aria-hidden="true"></span>';
+        grid.appendChild(overlay);
+        const ok = await fetchWishes();
+        overlay.remove();
+        if (!ok) return;
         grid.innerHTML = '';
         const filtered = WISHLIST.filter(item => !(onlyFree.checked && isReserved(item.id)));
         for (const item of filtered) {

--- a/styles.css
+++ b/styles.css
@@ -523,6 +523,17 @@ img {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: var(--gap);
+  position: relative;
+}
+
+.wish-grid__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 1;
 }
 .wish-card {
   display: flex;


### PR DESCRIPTION
## Summary
- Delay DOM clearing until after wishlist data is fetched
- Overlay loading spinner on wishlist grid
- Maintain existing wishlist when fetching reservations fails
- Fix unclosed catch block that broke wishlist rendering

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c658d2c1c832aa64f7e2d2b4f1b34