### PR TITLE
perf: reuse wishlist DOM for faster updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -241,6 +241,8 @@
       const reserveName = document.getElementById('reserveName');
       const reserveCancel = document.getElementById('reserveCancel');
       let reserveItemId = null;
+      const cardRefs = new Map(); // id -> {card, btn, pill, item}
+      let emptyCard = null;
       const supportsDialog = typeof HTMLDialogElement === 'function' && typeof reserveDialog.showModal === 'function';
       function openReserveDialog(){
         supportsDialog ? reserveDialog.showModal() : reserveDialog.classList.remove('hidden');
@@ -264,7 +266,7 @@
             if (ok) {
               SERVER_MAP = reservations || {};
               errorBanner.classList.add('hidden');
-              return;
+              return true;
             }
             throw new Error('bad response');
           } catch (e) {
@@ -276,6 +278,7 @@
             } catch (e2) {
               SERVER_MAP = {};
             }
+            return false;
           }
         }
 
@@ -291,25 +294,15 @@
         })[m]);
       }
 
-      async function renderWishlist() {
-        grid.innerHTML = WISHLIST.map(() => '<div class="wish-card skeleton" style="height:calc(128px + var(--gap))"></div>').join('');
-        await fetchWishes();
-        grid.innerHTML = '';
-        const filtered = WISHLIST.filter(item => !(onlyFree.checked && isReserved(item.id)));
-        for (const item of filtered) {
-          const reserved = isReserved(item.id);
-          const owner = reservedName(item.id);
-          const nameLabel = reserved ? `Забронировано — ${escapeHtml(owner)}` : 'Свободно';
-          const hasToken = !!getToken(item.id);
-
-          const card = document.createElement('div');
-          card.className = 'wish-card' + (reserved ? ' wish-card--reserved' : '');
+      function buildWishlist() {
+        const frag = document.createDocumentFragment();
+        for (const item of WISHLIST) {
           const safeLink = /^https?:\/\//i.test(item.link || '') ? item.link : '#';
           const thumb = item.image
             ? `<img src="${item.image}" alt="${escapeHtml(item.title)}" loading="lazy" width="128" height="128">`
             : '🎁';
-          const btnLabel = reserved ? (hasToken ? 'Снять бронь' : 'Забронировано') : 'Забронировать';
-          const btnDisabled = reserved && !hasToken ? 'disabled' : '';
+          const card = document.createElement('div');
+          card.className = 'wish-card';
           card.innerHTML = `
             <div class="wish-thumb" aria-hidden="true">${thumb}</div>
             <div class="wish-meta">
@@ -318,52 +311,83 @@
             </div>
             <div class="wish-actions">
                 <a class="btn btn--ghost" href="${safeLink}" target="_blank" rel="noopener noreferrer">Смотреть</a>
-              <span class="pill badge ${reserved ? 'reserved' : 'free'}">${nameLabel}</span>
-              <button class="btn btn--primary" ${btnDisabled} aria-pressed="${reserved}" data-id="${item.id}">
-                ${btnLabel}
+              <span class="pill badge free">Свободно</span>
+              <button class="btn btn--primary" aria-pressed="false" data-id="${item.id}">
+                Забронировать
               </button>
             </div>`;
-
           const btn = card.querySelector('button');
-          if (!btn.disabled) {
-            btn.addEventListener('click', async (e) => {
-              const id = e.currentTarget.getAttribute('data-id');
-              if (!isReserved(id)) {
-                reserveItemId = id;
-                reserveName.value = '';
-                openReserveDialog();
-              } else {
-                const token = getToken(id);
-                if (!token) { alert('Снять бронь можно с того же устройства, где она оформлялась, либо напишите организаторам.'); return; }
-                const btnEl = e.currentTarget;
-                btnEl.disabled = true;
-                const prevHtml = btnEl.innerHTML;
-                btnEl.innerHTML = '<span class="spinner" aria-hidden="true"></span>';
-                const r = await apiCancel(id, token);
-                if (!r || !r.ok) {
-                  alert('Не удалось снять бронь.');
-                  btnEl.disabled = false;
-                  btnEl.innerHTML = prevHtml;
-                  return;
-                }
-                clearToken(id);
-                await renderWishlist();
+          const pill = card.querySelector('.pill');
+          btn.addEventListener('click', async () => {
+            const id = item.id;
+            if (!isReserved(id)) {
+              reserveItemId = id;
+              reserveName.value = '';
+              openReserveDialog();
+            } else {
+              const token = getToken(id);
+              if (!token) { alert('Снять бронь можно с того же устройства, где она оформлялась, либо напишите организаторам.'); return; }
+              btn.disabled = true;
+              const prevHtml = btn.innerHTML;
+              btn.innerHTML = '<span class="spinner" aria-hidden="true"></span>';
+              const r = await apiCancel(id, token);
+              if (!r || !r.ok) {
+                alert('Не удалось снять бронь.');
+                btn.disabled = false;
+                btn.innerHTML = prevHtml;
+                return;
               }
-            });
-          }
+              clearToken(id);
+              await renderWishlist();
+            }
+          });
+          frag.appendChild(card);
+          cardRefs.set(item.id, { card, btn, pill, item });
+        }
+        emptyCard = document.createElement('div');
+        emptyCard.className = 'card';
+        emptyCard.textContent = 'Нет позиций по выбранному фильтру.';
+        emptyCard.hidden = true;
+        frag.appendChild(emptyCard);
+        grid.appendChild(frag);
+      }
 
-          grid.appendChild(card);
+      async function renderWishlist(skipFetch = false) {
+        let overlay;
+        if (!skipFetch) {
+          overlay = document.createElement('div');
+          overlay.className = 'wish-grid__overlay';
+          overlay.innerHTML = '<span class="spinner" aria-hidden="true"></span>';
+          grid.appendChild(overlay);
+          const ok = await fetchWishes();
+          overlay.remove();
+          if (!ok) return;
         }
-        if (!filtered.length) {
-          const empty = document.createElement('div');
-          empty.className = 'card';
-          empty.textContent = 'Нет позиций по выбранному фильтру.';
-          grid.appendChild(empty);
+        let visible = 0;
+        for (const [id, ref] of cardRefs) {
+          const { card, btn, pill } = ref;
+          const reserved = isReserved(id);
+          const owner = reservedName(id);
+          const nameLabel = reserved ? `Забронировано — ${escapeHtml(owner)}` : 'Свободно';
+          const hasToken = !!getToken(id);
+
+          card.classList.toggle('wish-card--reserved', reserved);
+          pill.textContent = nameLabel;
+          pill.className = 'pill badge ' + (reserved ? 'reserved' : 'free');
+          btn.innerHTML = reserved ? (hasToken ? 'Снять бронь' : 'Забронировано') : 'Забронировать';
+          btn.disabled = reserved && !hasToken;
+          btn.setAttribute('aria-pressed', reserved);
+
+          const hidden = onlyFree.checked && reserved;
+          card.hidden = hidden;
+          if (!hidden) visible++;
         }
+        emptyCard.hidden = visible !== 0;
       }
 
       hydrateBasics();
       startCountdown();
+      buildWishlist();
       renderWishlist();
       setInterval(renderWishlist, 45000);
       document.addEventListener('visibilitychange', () => { if (!document.hidden) renderWishlist(); });
@@ -384,7 +408,7 @@
     document.getElementById('copyAddr').addEventListener('click', copyAddress);
       onlyFree.addEventListener('change', () => {
         localStorage.setItem('onlyFree', onlyFree.checked ? '1' : '0');
-        renderWishlist();
+        renderWishlist(true);
       });
       reserveCancel.addEventListener('click', () => closeReserveDialog());
       reserveForm.addEventListener('submit', async (e) => {

--- a/styles.css
+++ b/styles.css
@@ -523,6 +523,17 @@ img {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: var(--gap);
+  position: relative;
+}
+
+.wish-grid__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.6);
+  z-index: 1;
 }
 .wish-card {
   display: flex;


### PR DESCRIPTION
## Summary
- Build wishlist once and reuse DOM nodes for subsequent updates
- Update renderWishlist to toggle existing items and skip network fetch when filtering
- Preserve loading spinner overlay and keep old list on failures

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c658d2c1c832aa64f7e2d2b4f1b34